### PR TITLE
Add case sensitivity and natural order options for the object properties rule

### DIFF
--- a/docs/rules/destructuring-properties.md
+++ b/docs/rules/destructuring-properties.md
@@ -24,6 +24,25 @@ let { b, C } = {}
 let { a: b, b: a } = {}
 ```
 
+## Options
+
+```json
+{
+  "sort/destructuring-properties": [
+    "error",
+    { "caseSensitive": false, "natural": true }
+  ]
+}
+```
+
+- `caseSensitive` - if `true`, enforce properties to be in case-sensitive order.
+  Default is `false`.
+- `natural` - if `true`, enforce properties to be in natural order. Default is
+  `true`. Natural Order compares strings containing combination of letters and
+  numbers in the way a human being would sort. It basically sorts numerically,
+  instead of sorting alphabetically. So the number 10 comes after the number 3
+  in Natural Sorting.
+
 ## When Not To Use It
 
 This rule is a formatting preference and not following it won't negatively

--- a/docs/rules/destructuring-properties.md
+++ b/docs/rules/destructuring-properties.md
@@ -35,13 +35,13 @@ let { a: b, b: a } = {}
 }
 ```
 
-- `caseSensitive` - if `true`, enforce properties to be in case-sensitive order.
-  Default is `false`.
-- `natural` - if `true`, enforce properties to be in natural order. Default is
-  `true`. Natural Order compares strings containing combination of letters and
+- `caseSensitive` (default `false`) - if `true`, enforce properties to be in
+  case-sensitive order.
+- `natural` (default `true`) - if `true`, enforce properties to be in natural
+  order. Natural order compares strings containing combination of letters and
   numbers in the way a human being would sort. It basically sorts numerically,
   instead of sorting alphabetically. So the number 10 comes after the number 3
-  in Natural Sorting.
+  in natural sorting.
 
 ## When Not To Use It
 

--- a/docs/rules/export-members.md
+++ b/docs/rules/export-members.md
@@ -31,13 +31,13 @@ export { a as b, b as a } from "a"
 }
 ```
 
-- `caseSensitive` - if `true`, enforce properties to be in case-sensitive order.
-  Default is `false`.
-- `natural` - if `true`, enforce properties to be in natural order. Default is
-  `true`. Natural Order compares strings containing combination of letters and
+- `caseSensitive` (default `false`) - if `true`, enforce properties to be in
+  case-sensitive order.
+- `natural` (default `true`) - if `true`, enforce properties to be in natural
+  order. Natural order compares strings containing combination of letters and
   numbers in the way a human being would sort. It basically sorts numerically,
   instead of sorting alphabetically. So the number 10 comes after the number 3
-  in Natural Sorting.
+  in natural sorting.
 
 ## When Not To Use It
 

--- a/docs/rules/export-members.md
+++ b/docs/rules/export-members.md
@@ -23,6 +23,22 @@ export { b, C } from "a"
 export { a as b, b as a } from "a"
 ```
 
+## Options
+
+```json
+{
+  "sort/export-members": ["error", { "caseSensitive": false, "natural": true }]
+}
+```
+
+- `caseSensitive` - if `true`, enforce properties to be in case-sensitive order.
+  Default is `false`.
+- `natural` - if `true`, enforce properties to be in natural order. Default is
+  `true`. Natural Order compares strings containing combination of letters and
+  numbers in the way a human being would sort. It basically sorts numerically,
+  instead of sorting alphabetically. So the number 10 comes after the number 3
+  in Natural Sorting.
+
 ## When Not To Use It
 
 This rule is a formatting preference and not following it won't negatively

--- a/docs/rules/import-members.md
+++ b/docs/rules/import-members.md
@@ -23,6 +23,22 @@ import { b, C } from "a"
 import { a as b, b as a } from "a"
 ```
 
+## Options
+
+```json
+{
+  "sort/import-members": ["error", { "caseSensitive": false, "natural": true }]
+}
+```
+
+- `caseSensitive` - if `true`, enforce properties to be in case-sensitive order.
+  Default is `false`.
+- `natural` - if `true`, enforce properties to be in natural order. Default is
+  `true`. Natural Order compares strings containing combination of letters and
+  numbers in the way a human being would sort. It basically sorts numerically,
+  instead of sorting alphabetically. So the number 10 comes after the number 3
+  in Natural Sorting.
+
 ## When Not To Use It
 
 This rule is a formatting preference and not following it won't negatively

--- a/docs/rules/import-members.md
+++ b/docs/rules/import-members.md
@@ -31,13 +31,13 @@ import { a as b, b as a } from "a"
 }
 ```
 
-- `caseSensitive` - if `true`, enforce properties to be in case-sensitive order.
-  Default is `false`.
-- `natural` - if `true`, enforce properties to be in natural order. Default is
-  `true`. Natural Order compares strings containing combination of letters and
+- `caseSensitive` (default `false`) - if `true`, enforce properties to be in
+  case-sensitive order.
+- `natural` (default `true`) - if `true`, enforce properties to be in natural
+  order. Natural order compares strings containing combination of letters and
   numbers in the way a human being would sort. It basically sorts numerically,
   instead of sorting alphabetically. So the number 10 comes after the number 3
-  in Natural Sorting.
+  in natural sorting.
 
 ## When Not To Use It
 

--- a/docs/rules/object-properties.md
+++ b/docs/rules/object-properties.md
@@ -23,6 +23,29 @@ var a = { b: 1, C: 2 }
 var a = { b: { x: 1, y: 2 }, C: 1 }
 ```
 
+## Options
+
+```json
+{
+  "sort-keys": ["error", "asc", { "caseSensitive": false, "natural": false }]
+}
+```
+
+The 1st option is `"asc"` or `"desc"`.
+
+- `"asc"` (default) - enforce properties to be in ascending order.
+- `"desc"` - enforce properties to be in descending order.
+
+The 2nd option is an object which has 3 properties.
+
+- `caseSensitive` - if `true`, enforce properties to be in case-sensitive order.
+  Default is `false`.
+- `natural` - if `true`, enforce properties to be in natural order. Default is
+  `false`. Natural Order compares strings containing combination of letters and
+  numbers in the way a human being would sort. It basically sorts numerically,
+  instead of sorting alphabetically. So the number 10 comes after the number 3
+  in Natural Sorting.
+
 ## When Not To Use It
 
 This rule is a formatting preference and not following it won't negatively

--- a/docs/rules/object-properties.md
+++ b/docs/rules/object-properties.md
@@ -34,13 +34,13 @@ var a = { b: { x: 1, y: 2 }, C: 1 }
 }
 ```
 
-- `caseSensitive` - if `true`, enforce properties to be in case-sensitive order.
-  Default is `false`.
-- `natural` - if `true`, enforce properties to be in natural order. Default is
-  `true`. Natural Order compares strings containing combination of letters and
+- `caseSensitive` (default `false`) - if `true`, enforce properties to be in
+  case-sensitive order.
+- `natural` (default `true`) - if `true`, enforce properties to be in natural
+  order. Natural order compares strings containing combination of letters and
   numbers in the way a human being would sort. It basically sorts numerically,
   instead of sorting alphabetically. So the number 10 comes after the number 3
-  in Natural Sorting.
+  in natural sorting.
 
 ## When Not To Use It
 

--- a/docs/rules/object-properties.md
+++ b/docs/rules/object-properties.md
@@ -27,21 +27,17 @@ var a = { b: { x: 1, y: 2 }, C: 1 }
 
 ```json
 {
-  "sort-keys": ["error", "asc", { "caseSensitive": false, "natural": false }]
+  "sort/object-properties": [
+    "error",
+    { "caseSensitive": false, "natural": true }
+  ]
 }
 ```
-
-The 1st option is `"asc"` or `"desc"`.
-
-- `"asc"` (default) - enforce properties to be in ascending order.
-- `"desc"` - enforce properties to be in descending order.
-
-The 2nd option is an object which has 2 properties.
 
 - `caseSensitive` - if `true`, enforce properties to be in case-sensitive order.
   Default is `false`.
 - `natural` - if `true`, enforce properties to be in natural order. Default is
-  `false`. Natural Order compares strings containing combination of letters and
+  `true`. Natural Order compares strings containing combination of letters and
   numbers in the way a human being would sort. It basically sorts numerically,
   instead of sorting alphabetically. So the number 10 comes after the number 3
   in Natural Sorting.

--- a/docs/rules/object-properties.md
+++ b/docs/rules/object-properties.md
@@ -36,7 +36,7 @@ The 1st option is `"asc"` or `"desc"`.
 - `"asc"` (default) - enforce properties to be in ascending order.
 - `"desc"` - enforce properties to be in descending order.
 
-The 2nd option is an object which has 3 properties.
+The 2nd option is an object which has 2 properties.
 
 - `caseSensitive` - if `true`, enforce properties to be in case-sensitive order.
   Default is `false`.

--- a/docs/rules/type-properties.md
+++ b/docs/rules/type-properties.md
@@ -44,6 +44,22 @@ type A = {
 }
 ```
 
+## Options
+
+```json
+{
+  "sort/type-properties": ["error", { "caseSensitive": false, "natural": true }]
+}
+```
+
+- `caseSensitive` - if `true`, enforce properties to be in case-sensitive order.
+  Default is `false`.
+- `natural` - if `true`, enforce properties to be in natural order. Default is
+  `true`. Natural Order compares strings containing combination of letters and
+  numbers in the way a human being would sort. It basically sorts numerically,
+  instead of sorting alphabetically. So the number 10 comes after the number 3
+  in Natural Sorting.
+
 ## When Not To Use It
 
 This rule is a formatting preference and not following it won't negatively

--- a/docs/rules/type-properties.md
+++ b/docs/rules/type-properties.md
@@ -52,13 +52,13 @@ type A = {
 }
 ```
 
-- `caseSensitive` - if `true`, enforce properties to be in case-sensitive order.
-  Default is `false`.
-- `natural` - if `true`, enforce properties to be in natural order. Default is
-  `true`. Natural Order compares strings containing combination of letters and
+- `caseSensitive` (default `false`) - if `true`, enforce properties to be in
+  case-sensitive order.
+- `natural` (default `true`) - if `true`, enforce properties to be in natural
+  order. Natural order compares strings containing combination of letters and
   numbers in the way a human being would sort. It basically sorts numerically,
   instead of sorting alphabetically. So the number 10 comes after the number 3
-  in Natural Sorting.
+  in natural sorting.
 
 ## When Not To Use It
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "eslint": ">=6"
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "^5.27.1"
+    "@typescript-eslint/experimental-utils": "^5.27.1",
+    "natural-compare": "^1.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.10",
@@ -49,7 +50,6 @@
     "eslint": "^8.17.0",
     "eslint-config-prettier": "^8.5.0",
     "jest": "^28.1.1",
-    "natural-compare": "^1.4.0",
     "prettier": "^2.6.2",
     "semantic-release": "^19.0.2",
     "typescript": "^4.7.3"

--- a/src/__tests__/destructuring-properties.spec.ts
+++ b/src/__tests__/destructuring-properties.spec.ts
@@ -1,5 +1,6 @@
 import { RuleTester } from "eslint"
 import rule from "../rules/destructuring-properties"
+import { createValidCodeVariants } from "../test-utils"
 
 const ruleTester = new RuleTester({
   parserOptions: {
@@ -9,34 +10,68 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("sort/destructuring-properties", rule, {
   valid: [
-    "let {} = {}",
-    "let {a} = {}",
-    "let {a, b, c} = {}",
-    "let {_, a, b} = {}",
-    "let {p,q,r,s,t,u,v,w,x,y,z} = {}",
-
-    // Case insensitive
-    "let {a, B, c, D} = {}",
-    "let {_, A, b} = {}",
+    ...createValidCodeVariants("let {} = {}"),
+    ...createValidCodeVariants("let { a } = {}"),
+    ...createValidCodeVariants("let { a, b, c } = {}"),
+    ...createValidCodeVariants("let { _, a, b } = {}"),
+    ...createValidCodeVariants("let { p, q, r, s, t, u, v, w, x, y, z } = {}"),
 
     // Aliases
-    "let {a: b, b: a} = {}",
+    ...createValidCodeVariants("let { a: b, b: a } = {}"),
 
     // Rest element
-    "let {a, b, ...c} = {}",
-    "let {...rest} = {}",
+    ...createValidCodeVariants("let { a, b, ...c } = {}"),
+    ...createValidCodeVariants("let { ...rest } = {}"),
 
     // Comments
-    `
-      let {
-        // a
-        a,
-        // b
-        b,
-        // rest
-        ...rest
-      } = {}
-    `.trim(),
+    ...createValidCodeVariants(
+      `
+        let {
+          // a
+          a,
+          // b
+          b,
+          // rest
+          ...rest
+        } = {}
+      `.trim()
+    ),
+
+    // Numeric properties
+    {
+      code: "let { 1: a, 11: b, 2: c } = {}",
+      options: [{ caseSensitive: false, natural: false }],
+    },
+    {
+      code: "let { 1: a, 11: b, 2: c } = {}",
+      options: [{ caseSensitive: true, natural: false }],
+    },
+    {
+      code: "let { 1: a, 2: c, 11: b } = {}",
+      options: [{ caseSensitive: false, natural: true }],
+    },
+    {
+      code: "let { 1: a, 2: c, 11: b } = {}",
+      options: [{ caseSensitive: true, natural: true }],
+    },
+
+    // Case sensitive
+    {
+      code: "let { a: A, B: b, C: c, c: C } = {}",
+      options: [{ caseSensitive: false, natural: false }],
+    },
+    {
+      code: "let { a: A, B: b, c: C, C: c } = {}",
+      options: [{ caseSensitive: true, natural: false }],
+    },
+    {
+      code: "let { a: A, B: b, c: C, C: c } = {}",
+      options: [{ caseSensitive: false, natural: true }],
+    },
+    {
+      code: "let { B: b, C: c, a: A, c: C } = {}",
+      options: [{ caseSensitive: true, natural: true }],
+    },
   ],
   invalid: [
     {

--- a/src/__tests__/export-members.spec.ts
+++ b/src/__tests__/export-members.spec.ts
@@ -1,5 +1,6 @@
 import { RuleTester } from "eslint"
 import rule from "../rules/export-members"
+import { createValidCodeVariants } from "../test-utils"
 
 const ruleTester = new RuleTester({
   parserOptions: {
@@ -10,34 +11,52 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("sort/export-members", rule, {
   valid: [
-    "export {} from 'a'",
-    "export {a} from 'a'",
-    "export {a, b, c} from 'a'",
-    "export {_, a, b} from 'a'",
-    "export {p,q,r,s,t,u,v,w,x,y,z} from 'a'",
-
-    // Case insensitive
-    "export {a, B, c, D} from 'a'",
-    "export {_, A, b} from 'a'",
+    ...createValidCodeVariants("export {} from 'a'"),
+    ...createValidCodeVariants("export { a } from 'a'"),
+    ...createValidCodeVariants("export { a, b, c } from 'a'"),
+    ...createValidCodeVariants("export { _, a, b } from 'a'"),
+    ...createValidCodeVariants(
+      "export { p, q, r, s, t, u, v, w, x, y, z } from 'a'"
+    ),
 
     // Default and namespace exports
-    "export default React",
-    "export * from 'a'",
+    ...createValidCodeVariants("export default React"),
+    ...createValidCodeVariants("export * from 'a'"),
 
     // Export aliases
-    "export {a as b, b as a} from 'a'",
+    ...createValidCodeVariants("export { a as b, b as a } from 'a'"),
 
     // Comments
-    `
-      export {
-        // a
-        a,
-        // b
-        b,
-        // c
-        c
-      } from 'a'
-    `.trim(),
+    ...createValidCodeVariants(
+      `
+        export {
+          // a
+          a,
+          // b
+          b,
+          // c
+          c
+        } from 'a'
+      `.trim()
+    ),
+
+    // Case sensitive
+    {
+      code: "export { a, B, C, c } from 'a'",
+      options: [{ caseSensitive: false, natural: false }],
+    },
+    {
+      code: "export { a, B, c, C } from 'a'",
+      options: [{ caseSensitive: true, natural: false }],
+    },
+    {
+      code: "export { a, B, C, c } from 'a'",
+      options: [{ caseSensitive: false, natural: true }],
+    },
+    {
+      code: "export { B, C, a, c } from 'a'",
+      options: [{ caseSensitive: true, natural: true }],
+    },
   ],
   invalid: [
     {

--- a/src/__tests__/import-members.spec.ts
+++ b/src/__tests__/import-members.spec.ts
@@ -1,5 +1,6 @@
 import { RuleTester } from "eslint"
 import rule from "../rules/import-members"
+import { createValidCodeVariants } from "../test-utils"
 
 const ruleTester = new RuleTester({
   parserOptions: {
@@ -10,26 +11,25 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("sort/import-members", rule, {
   valid: [
-    "import {} from 'a'",
-    "import {a} from 'a'",
-    "import {a, b, c} from 'a'",
-    "import {_, a, b} from 'a'",
-    "import {p,q,r,s,t,u,v,w,x,y,z} from 'a'",
-
-    // Case insensitive
-    "import {a, B, c, D} from 'a'",
-    "import {_, A, b} from 'a'",
+    ...createValidCodeVariants("import {} from 'a'"),
+    ...createValidCodeVariants("import { a } from 'a'"),
+    ...createValidCodeVariants("import { a, b, c } from 'a'"),
+    ...createValidCodeVariants("import { _, a, b } from 'a'"),
+    ...createValidCodeVariants(
+      "import { p, q, r, s, t, u, v, w, x, y, z } from 'a'"
+    ),
 
     // Default and namespace imports
-    "import React from 'a'",
-    "import * as React from 'a'",
-    "import React, {a, b} from 'a'",
+    ...createValidCodeVariants("import React from 'a'"),
+    ...createValidCodeVariants("import * as React from 'a'"),
+    ...createValidCodeVariants("import React, { a, b } from 'a'"),
 
     // Import aliases
-    "import {a as b, b as a} from 'a'",
+    ...createValidCodeVariants("import { a as b, b as a } from 'a'"),
 
     // Comments
-    `
+    ...createValidCodeVariants(
+      `
       import {
         // a
         a,
@@ -37,7 +37,26 @@ ruleTester.run("sort/import-members", rule, {
         b,
         c
       } from 'a'
-    `.trim(),
+    `.trim()
+    ),
+
+    // Case sensitive
+    {
+      code: "import { a, B, C, c } from 'a'",
+      options: [{ caseSensitive: false, natural: false }],
+    },
+    {
+      code: "import { a, B, c, C } from 'a'",
+      options: [{ caseSensitive: true, natural: false }],
+    },
+    {
+      code: "import { a, B, C, c } from 'a'",
+      options: [{ caseSensitive: false, natural: true }],
+    },
+    {
+      code: "import { B, C, a, c } from 'a'",
+      options: [{ caseSensitive: true, natural: true }],
+    },
   ],
   invalid: [
     {

--- a/src/__tests__/object-properties.spec.ts
+++ b/src/__tests__/object-properties.spec.ts
@@ -1,5 +1,6 @@
 import { RuleTester } from "eslint"
 import rule from "../rules/object-properties"
+import { createValidCodeVariants } from "../test-utils"
 
 const ruleTester = new RuleTester({
   parserOptions: {
@@ -9,38 +10,47 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("sort/object-properties", rule, {
   valid: [
-    /*
-     * asc, case insensitive, non-natural order (default)
-     */
-    { code: "var a = {}" },
-    { code: "var a = {a: 1}" },
-    { code: "var a = {a: 1, b: 2, c: 3}" },
-    { code: "var a = {_:1, a:2, b:3}" },
-    { code: "var a = {1:'a', 11: 'b', 2:'c'}" },
+    // Empty object
+    ...createValidCodeVariants("var a = {}"),
+
+    // Single property
+    ...createValidCodeVariants("var a = { a: 1 }"),
+
+    // Multiple properties
+    ...createValidCodeVariants("var a = { a: 1, b: 2, c: 3 }"),
+
+    // Multiple properties with special characters
+    ...createValidCodeVariants("var a = { _: 1, a: 2, b: 3 }"),
+
     // Bracket notation
-    { code: "var a = {['a']: 1, ['b']: 2}" },
-    { code: "var a = {[1]: 'a', [2]: 'b'}" },
-    // Case insensitive
-    {
-      code: "var a = {a:1, B:2, c:3, D:4}",
-    },
-    {
-      code: "var a = {_:1, A:2, b:3}",
-    },
+    ...createValidCodeVariants("var a = { ['a']: 1, ['b']: 2 }"),
+    ...createValidCodeVariants("var a = { [1]: 'a', [2]: 'b' }"),
+
     // Template literals
-    { code: "var a = {[`a`]: 1, [`b`]: 2}" },
-    { code: "var a = {[`a${b}c${d}`]: 1, [`a${c}e${g}`]: 2}" },
-    { code: "var a = {[`${a}b${c}d`]: 1, [`${a}c${e}g`]: 2}" },
+    ...createValidCodeVariants("var a = { [`a`]: 1, [`b`]: 2 }"),
+    ...createValidCodeVariants(
+      "var a = { [`a${b}c${d}`]: 1, [`a${c}e${g}`]: 2 }"
+    ),
+    ...createValidCodeVariants(
+      "var a = { [`${a}b${c}d`]: 1, [`${a}c${e}g`]: 2 }"
+    ),
+
     // Spread elements
-    { code: "var a = {a:1, b:2, ...c, d:3, e:4}" },
-    { code: "var a = {d:1, e:2, ...c, a:3, b:4}" },
-    { code: "var a = {e:1, f:2, ...d, ...c, a:3, b:4}" },
-    { code: "var a = {f:1, g:2, ...d, a:3, ...c, b:4, c:5}" },
+    ...createValidCodeVariants("var a = { a: 1, b: 2, ...c, d: 3, e: 4 }"),
+    ...createValidCodeVariants("var a = { d: 1, e: 2, ...c, a: 3, b: 4 }"),
+    ...createValidCodeVariants(
+      "var a = { e: 1, f: 2, ...d, ...c, a: 3, b: 4 }"
+    ),
+    ...createValidCodeVariants(
+      "var a = { f: 1, g: 2, ...d, a: 3, ...c, b: 4, c: 5 }"
+    ),
+
     // Nested properties
-    { code: "var a = {a:1, b:{x:2, y:3}, c:4}" },
+    ...createValidCodeVariants("var a = { a: 1, b: { x: 2, y: 3 }, c: 4 }"),
+
     // Comments
-    {
-      code: `
+    ...createValidCodeVariants(
+      `
         var a = {
           // c
           c: 1,
@@ -52,189 +62,79 @@ ruleTester.run("sort/object-properties", rule, {
           a: 3,
           b: 4
         }
-      `.trim(),
+      `.trim()
+    ),
+
+    // Numeric properties
+    {
+      code: "var a = { 1: 'a', 11: 'b', 2: 'c' }",
+      options: [{ caseSensitive: false, natural: false }],
+    },
+    {
+      code: "var a = { 1: 'a', 11: 'b', 2: 'c' }",
+      options: [{ caseSensitive: true, natural: false }],
+    },
+    {
+      code: "var a = { 1: 'a', 2: 'c', 11: 'b' }",
+      options: [{ caseSensitive: false, natural: true }],
+    },
+    {
+      code: "var a = { 1: 'a', 2: 'c', 11: 'b' }",
+      options: [{ caseSensitive: true, natural: true }],
     },
 
-    /*
-     * asc, case sensitive, non-natural order
-     */
-    { code: "var a = {}", options: ["asc", { caseSensitive: true }] },
-    { code: "var a = {a: 1}", options: ["asc", { caseSensitive: true }] },
+    // Numeric properties + bracket notation
     {
-      code: "var a = {a: 1, b: 2, c: 3}",
-      options: ["asc", { caseSensitive: true }],
+      code: "var a = { [1]: 'a', [11]: 'b', [2]: 'c' }",
+      options: [{ caseSensitive: false, natural: false }],
     },
     {
-      code: "var a = {_:1, a:2, b:3}",
-      options: ["asc", { caseSensitive: true }],
+      code: "var a = { [1]: 'a', [11]: 'b', [2]: 'c' }",
+      options: [{ caseSensitive: true, natural: false }],
     },
     {
-      code: "var a = {1:'a', 11: 'b', 2:'c'}",
-      options: ["asc", { caseSensitive: true }],
-    },
-    // Bracket notation
-    {
-      code: "var a = {['a']: 1, ['b']: 2}",
-      options: ["asc", { caseSensitive: true }],
+      code: "var a = { [1]: 'a', [2]: 'c', [11]: 'b' }",
+      options: [{ caseSensitive: false, natural: true }],
     },
     {
-      code: "var a = {[1]: 'a', [2]: 'b'}",
-      options: ["asc", { caseSensitive: true }],
-    },
-    // Case insensitive
-    {
-      code: "var a = {a:1, B:2, c:3, D:4}",
-      options: ["asc", { caseSensitive: true }],
-    },
-    {
-      code: "var a = {_:1, A:2, b:3}",
-      options: ["asc", { caseSensitive: true }],
-    },
-    // Template literals
-    {
-      code: "var a = {[`a`]: 1, [`b`]: 2}",
-      options: ["asc", { caseSensitive: true }],
-    },
-    {
-      code: "var a = {[`a${b}c${d}`]: 1, [`a${c}e${g}`]: 2}",
-      options: ["asc", { caseSensitive: true }],
-    },
-    {
-      code: "var a = {[`${a}b${c}d`]: 1, [`${a}c${e}g`]: 2}",
-      options: ["asc", { caseSensitive: true }],
-    },
-    // Spread elements
-    {
-      code: "var a = {a:1, b:2, ...c, d:3, e:4}",
-      options: ["asc", { caseSensitive: true }],
-    },
-    {
-      code: "var a = {d:1, e:2, ...c, a:3, b:4}",
-      options: ["asc", { caseSensitive: true }],
-    },
-    {
-      code: "var a = {e:1, f:2, ...d, ...c, a:3, b:4}",
-      options: ["asc", { caseSensitive: true }],
-    },
-    {
-      code: "var a = {f:1, g:2, ...d, a:3, ...c, b:4, c:5}",
-      options: ["asc", { caseSensitive: true }],
-    },
-    // Nested properties
-    {
-      code: "var a = {a:1, b:{x:2, y:3}, c:4}",
-      options: ["asc", { caseSensitive: true }],
-    },
-    // Comments
-    {
-      code: `
-        var a = {
-          // c
-          c: 1,
-          // d
-          d: 2,
-          ...spread1,
-          // spread 2
-          ...spread2,
-          a: 3,
-          b: 4
-        }
-      `.trim(),
-      options: ["asc", { caseSensitive: true }],
+      code: "var a = { [1]: 'a', [2]: 'c', [11]: 'b' }",
+      options: [{ caseSensitive: true, natural: true }],
     },
 
-    /*
-     * asc, case sensitive, natural order
-     */
+    // Case sensitive
     {
-      code: "var a = {}",
-      options: ["asc", { caseSensitive: true, natural: true }],
+      code: "var a = { a: 1, B: 2, c: 3, C: 4 }",
+      options: [{ caseSensitive: false, natural: false }],
     },
     {
-      code: "var a = {a: 1}",
-      options: ["asc", { caseSensitive: true, natural: true }],
+      code: "var a = { a: 1, B: 2, c: 3, C: 4 }",
+      options: [{ caseSensitive: true, natural: false }],
     },
     {
-      code: "var a = {a: 1, b: 2, c: 3}",
-      options: ["asc", { caseSensitive: true, natural: true }],
+      code: "var a = { a: 1, B: 2, c: 3, C: 4 }",
+      options: [{ caseSensitive: false, natural: true }],
     },
     {
-      code: "var a = {_:1, a:2, b:3}",
-      options: ["asc", { caseSensitive: true, natural: true }],
+      code: "var a = { B: 2, C: 4, a: 1, c: 3 }",
+      options: [{ caseSensitive: true, natural: true }],
+    },
+
+    // Case sensitive + bracket notation
+    {
+      code: "var a = { ['a']: 1, ['B']: 2, ['c']: 3, ['C']: 4 }",
+      options: [{ caseSensitive: false, natural: false }],
     },
     {
-      code: "var a = {1:'a', 2:'c', 11: 'b'}",
-      options: ["asc", { caseSensitive: true, natural: true }],
-    },
-    // Bracket notation
-    {
-      code: "var a = {['a']: 1, ['b']: 2}",
-      options: ["asc", { caseSensitive: true, natural: true }],
+      code: "var a = { ['a']: 1, ['B']: 2, ['c']: 3, ['C']: 4, }",
+      options: [{ caseSensitive: true, natural: false }],
     },
     {
-      code: "var a = {[1]: 'a', [2]: 'b'}",
-      options: ["asc", { caseSensitive: true, natural: true }],
-    },
-    // Case insensitive
-    {
-      code: "var a = {B:2, D:4, a:1, c:3}",
-      options: ["asc", { caseSensitive: true, natural: true }],
+      code: "var a = { ['a']: 1, ['B']: 2, ['c']: 3, ['C']: 4 }",
+      options: [{ caseSensitive: false, natural: true }],
     },
     {
-      code: "var a = {_:1, A:2, b:3}",
-      options: ["asc", { caseSensitive: true, natural: true }],
-    },
-    // Template literals
-    {
-      code: "var a = {[`a`]: 1, [`b`]: 2}",
-      options: ["asc", { caseSensitive: true, natural: true }],
-    },
-    {
-      code: "var a = {[`a${b}c${d}`]: 1, [`a${c}e${g}`]: 2}",
-      options: ["asc", { caseSensitive: true, natural: true }],
-    },
-    {
-      code: "var a = {[`${a}b${c}d`]: 1, [`${a}c${e}g`]: 2}",
-      options: ["asc", { caseSensitive: true, natural: true }],
-    },
-    // Spread elements
-    {
-      code: "var a = {a:1, b:2, ...c, d:3, e:4}",
-      options: ["asc", { caseSensitive: true, natural: true }],
-    },
-    {
-      code: "var a = {d:1, e:2, ...c, a:3, b:4}",
-      options: ["asc", { caseSensitive: true, natural: true }],
-    },
-    {
-      code: "var a = {e:1, f:2, ...d, ...c, a:3, b:4}",
-      options: ["asc", { caseSensitive: true, natural: true }],
-    },
-    {
-      code: "var a = {f:1, g:2, ...d, a:3, ...c, b:4, c:5}",
-      options: ["asc", { caseSensitive: true, natural: true }],
-    },
-    // Nested properties
-    {
-      code: "var a = {a:1, b:{x:2, y:3}, c:4}",
-      options: ["asc", { caseSensitive: true, natural: true }],
-    },
-    // Comments
-    {
-      code: `
-        var a = {
-          // c
-          c: 1,
-          // d
-          d: 2,
-          ...spread1,
-          // spread 2
-          ...spread2,
-          a: 3,
-          b: 4
-        }
-      `.trim(),
-      options: ["asc", { caseSensitive: true, natural: true }],
+      code: "var a = { ['B']: 2, ['C']: 4, ['a']: 1, ['c']: 3 }",
+      options: [{ caseSensitive: true, natural: true }],
     },
   ],
   invalid: [

--- a/src/__tests__/object-properties.spec.ts
+++ b/src/__tests__/object-properties.spec.ts
@@ -83,7 +83,7 @@ ruleTester.run("sort/object-properties", rule, {
     },
     // Case insensitive
     {
-      code: "var a = {B:2, D:4, a:1, c:3}",
+      code: "var a = {a:1, B:2, c:3, D:4}",
       options: ["asc", { caseSensitive: true }],
     },
     {

--- a/src/__tests__/type-properties.spec.ts
+++ b/src/__tests__/type-properties.spec.ts
@@ -1,23 +1,54 @@
-import { ESLintUtils } from "@typescript-eslint/experimental-utils"
+import { ESLintUtils, TSESLint } from "@typescript-eslint/experimental-utils"
 import rule from "../rules/type-properties"
 
 const ruleTester = new ESLintUtils.RuleTester({
   parser: "@typescript-eslint/parser",
 })
 
+const createValidCodeVariants = (
+  code: string
+): TSESLint.RunTests<
+  "unsorted",
+  [{ caseSensitive?: boolean; natural?: boolean }]
+>["valid"] => {
+  return [
+    { code, options: [{ caseSensitive: false, natural: false }] },
+    { code, options: [{ caseSensitive: true, natural: false }] },
+    { code, options: [{ caseSensitive: false, natural: true }] },
+    { code, options: [{ caseSensitive: true, natural: true }] },
+  ]
+}
+
 ruleTester.run("sort/type-properties", rule, {
   valid: [
-    "interface A {a: string, b: number}",
-    "interface A {a: string}",
-    "interface A {}",
-    "type A = {_:string, a:string, b:string}",
+    // Interfaces
+    ...createValidCodeVariants("interface A {}"),
+    ...createValidCodeVariants("interface A { a: string }"),
+    ...createValidCodeVariants("interface A { a: string, b: number }"),
+    ...createValidCodeVariants(
+      "interface A { _: string, a: string, b: string }"
+    ),
 
-    // Case insensitive
-    "type A = {a:string, B:string, c:string, D:string}",
-    "type A = {_:string, A:string, b:string}",
+    // Types
+    ...createValidCodeVariants("type A = {}"),
+    ...createValidCodeVariants("type A = { a: string }"),
+    ...createValidCodeVariants("type A = { a: string, b: number }"),
+    ...createValidCodeVariants("type A = { _:string, a: string, b: string }"),
+
+    // Comments
+    ...createValidCodeVariants(
+      `
+        interface A {
+          // a
+          a: string
+          // b
+          b: number
+        }
+      `.trim()
+    ),
 
     // Weights
-    `
+    ...createValidCodeVariants(`
       interface A {
         new(f: string): void
         (e: string): void
@@ -26,17 +57,43 @@ ruleTester.run("sort/type-properties", rule, {
         d(): void
         [a: string]: unknown
       }
-    `,
+    `),
 
-    // Comments
-    `
-      interface A {
-        // a
-        a: string
-        // b
-        b: number
-      }
-    `.trim(),
+    // Numeric keys
+    {
+      code: "type A = { 1: 'a', 11: 'b', 2: 'c' }",
+      options: [{ caseSensitive: false, natural: false }],
+    },
+    {
+      code: "type A = { 1: 'a',  11: 'b', 2: 'c' }",
+      options: [{ caseSensitive: true, natural: false }],
+    },
+    {
+      code: "type A = { 1: 'a', 2: 'c', 11: 'b' }",
+      options: [{ caseSensitive: false, natural: true }],
+    },
+    {
+      code: "type A = { 1: 'a', 2: 'c', 11: 'b' }",
+      options: [{ caseSensitive: true, natural: true }],
+    },
+
+    // Case sensitive
+    {
+      code: "type A = { a: 1, B: 2, c: 3, C: 4 }",
+      options: [{ caseSensitive: false, natural: false }],
+    },
+    {
+      code: "type A = { a: 1, B: 2, c: 3, C: 4 }",
+      options: [{ caseSensitive: true, natural: false }],
+    },
+    {
+      code: "type A = { a: 1, B: 2, c: 3, C: 4 }",
+      options: [{ caseSensitive: false, natural: true }],
+    },
+    {
+      code: "type A = { B: 2, C: 4, a: 1, c: 3 }",
+      options: [{ caseSensitive: true, natural: true }],
+    },
   ],
   invalid: [
     {

--- a/src/rules/destructuring-properties.ts
+++ b/src/rules/destructuring-properties.ts
@@ -1,8 +1,14 @@
 import { Rule } from "eslint"
-import { alphaSorter, docsURL, filterNodes, getName, report } from "../utils"
+import { docsURL, filterNodes, getName, getSorter, report } from "../utils"
 
 export default {
   create(context) {
+    const options = context.options[0]
+    const sorter = getSorter({
+      caseSensitive: options?.caseSensitive,
+      natural: options?.natural,
+    })
+
     return {
       ObjectPattern(pattern) {
         const nodes = filterNodes(pattern.properties, ["Property"])
@@ -14,20 +20,38 @@ export default {
 
         const sorted = nodes
           .slice()
-          .sort(alphaSorter((node) => getName(node.key).toLowerCase()))
+          .sort((nodeA, nodeB) =>
+            sorter(getName(nodeA.key), getName(nodeB.key))
+          )
 
         report(context, nodes, sorted)
       },
     }
   },
   meta: {
-    type: "suggestion",
-    fixable: "code",
     docs: {
       url: docsURL("destructuring-properties"),
     },
+    fixable: "code",
     messages: {
       unsorted: "Destructuring properties should be sorted alphabetically.",
     },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          caseSensitive: {
+            type: "boolean",
+            default: false,
+          },
+          natural: {
+            type: "boolean",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    type: "suggestion",
   },
 } as Rule.RuleModule

--- a/src/rules/destructuring-properties.ts
+++ b/src/rules/destructuring-properties.ts
@@ -38,7 +38,8 @@ export default {
     },
     schema: [
       {
-        type: "object",
+        additionalProperties: false,
+        default: { caseSensitive: false, natural: true },
         properties: {
           caseSensitive: {
             type: "boolean",
@@ -49,7 +50,7 @@ export default {
             default: true,
           },
         },
-        additionalProperties: false,
+        type: "object",
       },
     ],
     type: "suggestion",

--- a/src/rules/export-members.ts
+++ b/src/rules/export-members.ts
@@ -1,8 +1,14 @@
 import { Rule } from "eslint"
-import { alphaSorter, docsURL, report } from "../utils"
+import { docsURL, getSorter, report } from "../utils"
 
 export default {
   create(context) {
+    const options = context.options[0]
+    const sorter = getSorter({
+      caseSensitive: options?.caseSensitive,
+      natural: options?.natural,
+    })
+
     return {
       ExportNamedDeclaration({ specifiers: nodes }) {
         // If there are one or fewer properties, there is nothing to sort
@@ -12,20 +18,36 @@ export default {
 
         const sorted = nodes
           .slice()
-          .sort(alphaSorter((node) => node.local.name.toLowerCase()))
+          .sort((nodeA, nodeB) => sorter(nodeA.local.name, nodeB.local.name))
 
         report(context, nodes, sorted)
       },
     }
   },
   meta: {
-    type: "suggestion",
-    fixable: "code",
     docs: {
       url: docsURL("export-members"),
     },
+    fixable: "code",
     messages: {
       unsorted: "Export members should be sorted alphabetically.",
     },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          caseSensitive: {
+            type: "boolean",
+            default: false,
+          },
+          natural: {
+            type: "boolean",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    type: "suggestion",
   },
 } as Rule.RuleModule

--- a/src/rules/export-members.ts
+++ b/src/rules/export-members.ts
@@ -34,7 +34,8 @@ export default {
     },
     schema: [
       {
-        type: "object",
+        additionalProperties: false,
+        default: { caseSensitive: false, natural: true },
         properties: {
           caseSensitive: {
             type: "boolean",
@@ -45,7 +46,7 @@ export default {
             default: true,
           },
         },
-        additionalProperties: false,
+        type: "object",
       },
     ],
     type: "suggestion",

--- a/src/rules/import-members.ts
+++ b/src/rules/import-members.ts
@@ -38,7 +38,8 @@ export default {
     },
     schema: [
       {
-        type: "object",
+        additionalProperties: false,
+        default: { caseSensitive: false, natural: true },
         properties: {
           caseSensitive: {
             type: "boolean",
@@ -49,7 +50,7 @@ export default {
             default: true,
           },
         },
-        additionalProperties: false,
+        type: "object",
       },
     ],
     type: "suggestion",

--- a/src/rules/import-members.ts
+++ b/src/rules/import-members.ts
@@ -1,8 +1,14 @@
 import { Rule } from "eslint"
-import { alphaSorter, docsURL, filterNodes, report } from "../utils"
+import { docsURL, filterNodes, getSorter, report } from "../utils"
 
 export default {
   create(context) {
+    const options = context.options[0]
+    const sorter = getSorter({
+      caseSensitive: options?.caseSensitive,
+      natural: options?.natural,
+    })
+
     return {
       ImportDeclaration(decl) {
         const nodes = filterNodes(decl.specifiers, ["ImportSpecifier"])
@@ -14,20 +20,38 @@ export default {
 
         const sorted = nodes
           .slice()
-          .sort(alphaSorter((node) => node.imported.name.toLowerCase()))
+          .sort((nodeA, nodeB) =>
+            sorter(nodeA.imported.name, nodeB.imported.name)
+          )
 
         report(context, nodes, sorted)
       },
     }
   },
   meta: {
-    type: "suggestion",
-    fixable: "code",
     docs: {
       url: docsURL("import-members"),
     },
+    fixable: "code",
     messages: {
       unsorted: "Import members should be sorted alphabetically.",
     },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          caseSensitive: {
+            type: "boolean",
+            default: false,
+          },
+          natural: {
+            type: "boolean",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    type: "suggestion",
   },
 } as Rule.RuleModule

--- a/src/rules/object-properties.ts
+++ b/src/rules/object-properties.ts
@@ -55,7 +55,8 @@ export default {
     },
     schema: [
       {
-        type: "object",
+        additionalProperties: false,
+        default: { caseSensitive: false, natural: true },
         properties: {
           caseSensitive: {
             type: "boolean",
@@ -66,7 +67,7 @@ export default {
             default: true,
           },
         },
-        additionalProperties: false,
+        type: "object",
       },
     ],
     type: "suggestion",

--- a/src/rules/object-properties.ts
+++ b/src/rules/object-properties.ts
@@ -64,12 +64,12 @@ export default {
     const order = context.options[0] || "asc"
     const options = context.options[1]
 
-    const isCaseInsensitive = options && options.caseSensitive === false
-    const isNaturalOrder = options && options.natural
+    const isCaseSensitive = options?.caseSensitive
+    const isNaturalOrder = options?.natural
 
     const sorter =
       sorters[
-        `${order}${isCaseInsensitive ? "I" : ""}${isNaturalOrder ? "N" : ""}`
+        `${order}${isCaseSensitive ? "" : "I"}${isNaturalOrder ? "N" : ""}`
       ]
 
     return {

--- a/src/rules/type-properties.ts
+++ b/src/rules/type-properties.ts
@@ -107,7 +107,8 @@ export default ESLintUtils.RuleCreator.withoutDocs<
     },
     schema: [
       {
-        type: "object",
+        additionalProperties: false,
+        default: { caseSensitive: false, natural: true },
         properties: {
           caseSensitive: {
             type: "boolean",
@@ -118,7 +119,7 @@ export default ESLintUtils.RuleCreator.withoutDocs<
             default: true,
           },
         },
-        additionalProperties: false,
+        type: "object",
       },
     ],
     type: "suggestion",

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,0 +1,12 @@
+import { RuleTester } from "eslint"
+
+export const createValidCodeVariants = (
+  code: string
+): RuleTester.ValidTestCase[] => {
+  return [
+    { code, options: [{ caseSensitive: false, natural: false }] },
+    { code, options: [{ caseSensitive: true, natural: false }] },
+    { code, options: [{ caseSensitive: false, natural: true }] },
+    { code, options: [{ caseSensitive: true, natural: true }] },
+  ]
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,8 +60,8 @@ export const filterNodes = <T extends Node, U extends T["type"]>(
  * of this function should be passed to `Array.prototype.sort()`.
  */
 export const getSorter = ({
-  caseSensitive,
-  natural,
+  caseSensitive = false,
+  natural = true,
 }: {
   caseSensitive?: boolean
   natural?: boolean

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { AST, Rule, SourceCode } from "eslint"
 import { Expression, Node } from "estree"
+import naturalCompare from "natural-compare"
 
 /**
  * Returns the first node in the source array that is different from the same
@@ -55,11 +56,25 @@ export const filterNodes = <T extends Node, U extends T["type"]>(
   )
 
 /**
- * Function that returns a simple alphanumeric sort function. The return value
+ * Functions which check that the given 2 names are in specific order. The return value
  * of this function should be passed to `Array.prototype.sort()`.
  */
-export function alphaSorter<T>(sortFn: (node: T) => string) {
-  return (a: T, b: T) => sortFn(a).localeCompare(sortFn(b))
+export const getSorter = ({
+  caseSensitive,
+  natural,
+}: {
+  caseSensitive?: boolean
+  natural?: boolean
+}): ((a: string, b: string) => number) => {
+  if (caseSensitive && natural) {
+    return (a, b) => naturalCompare(a, b)
+  } else if (caseSensitive) {
+    return (a, b) => a.localeCompare(b)
+  } else if (natural) {
+    return (a, b) => naturalCompare(a.toLowerCase(), b.toLowerCase())
+  }
+
+  return (a, b) => a.toLowerCase().localeCompare(b.toLowerCase())
 }
 
 /**


### PR DESCRIPTION
First of all, why is this repo not more hyped? 🤩 

Eslint's [`sort-keys`](https://github.com/eslint/eslint/blob/main/tests/lib/rules/sort-keys.js) rule supports options for case sensitivity and natural order. I personally rely on the natural order a lot for sorting Tailwind properties in a classname object, for example:

```ts
const classNames = clsx({
  "gap-1": gap === 1,
  "gap-2": gap === 2,
  // ...etc
 "gap-10": gap === 10
})
```

However, with the current default config for the object properties rule, the result would be the following:

```ts
const classNames = clsx({
  "gap-1": gap === 1,
  "gap-10": gap === 10,
  "gap-2": gap === 2,
  // ...etc
})
```

Having the option to set whether or not the rule should use natural sorting, would be a great addition so that the above object would sort numeric string in a 'natural' way using [`natural-compare`](https://www.npmjs.com/package/natural-compare)

To keep it aligned with `sort-key`, I also added the option to choose between `asc` and `desc` orders